### PR TITLE
Use released fork of github-api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
   jdbc,
   anorm,
   cache,
-  "org.kohsuke" % "github-api" % "1.50-SNAPSHOT",
+  "com.madgag" % "github-api" % "1.49.99.0.1",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.2",
   "org.eclipse.jgit" % "org.eclipse.jgit" % "3.2.0.201312181205-r",
   "com.madgag" %% "scala-git" % "1.11.1",


### PR DESCRIPTION
I've published a small fork of the github-api to Maven Central, which includes these pull-requests we need:

https://github.com/kohsuke/github-api/pull/66 - org member paging
https://github.com/kohsuke/github-api/pull/68 - org-member filtering
