### PR TITLE
Add Travis-CI config so we can detect compilation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: scala
+
+jdk:
+  - openjdk7
+
+script:
+  - sbt compile
+


### PR DESCRIPTION
Currently, running our tests seems to unintentionally do some real-live
ops, which we should probably review! So, in the mean time, this
configuration limits Travis to just running the 'compile' task.
