### PR TITLE
Fix 'X' users did not meet the requirements bug

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -32,9 +32,7 @@ object Application extends Controller {
 
         orgSnapshot.closeUnassignedIssues()
 
-        val problemUserCount = orgSnapshot.orgUserProblemsByUser.keySet.size
-
-        Ok(views.html.userPages.results(auditDef, problemUserCount))
+        Ok(views.html.userPages.results(auditDef, orgSnapshot))
       }
     } else future { NotAcceptable }
   }

--- a/app/lib/OrgSnapshot.scala
+++ b/app/lib/OrgSnapshot.scala
@@ -81,6 +81,8 @@ case class OrgSnapshot(
       )
   }.toMap
 
+  lazy val usersWithProblemsCount = orgUserProblemsByUser.values.count(_.problems.size > 0)
+
   lazy val orgUserProblemStats = orgUserProblemsByUser.values.map(_.problems.size).groupBy(identity).mapValues(_.size)
 
   def updateExistingAssignedIssues() {

--- a/app/views/userPages/results.scala.html
+++ b/app/views/userPages/results.scala.html
@@ -1,10 +1,10 @@
-@(auditDef: lib.AuditDef, problemUserCount: Int)(implicit req: Request[AnyContent])
+@(auditDef: lib.AuditDef, orgSnapsot: lib.OrgSnapshot)(implicit req: Request[AnyContent])
 @main {
 
     <div class="row">
         <div class="col-md-6">
             <h2>Your audit is complete</h2>
-            <p>We found @problemUserCount users that did not meet the requirements.</p>
+            <p>We found @orgSnapsot.usersWithProblemsCount users that did not meet the requirements.</p>
             <p>Our script has opened by these
                 <a href="https://github.com/@auditDef.org.getLogin/people/issues/created_by/@auditDef.bot.getLogin?state=open">issues</a>
                 by you


### PR DESCRIPTION
Previously the report said 'We found **128** users that did not meet the requirements.' for the Guardian org, which is thankfully not true!

This was my fault for pointing @lindseydew at the incorrect value to count...
