### PR TITLE
Be even more forgiving of short 'Full Names'

### DIFF
--- a/app/lib/AccountRequirement.scala
+++ b/app/lib/AccountRequirement.scala
@@ -50,7 +50,7 @@ object FullNameRequirement extends AccountRequirement {
 
   def userEvaluatorFor(orgSnapshot: OrgSnapshot) = Success(new UserEvaluator {
     def appliesTo(user: GHUser) = true
-    def isSatisfiedBy(user: GHUser) = Option(user.getName()).map(_.length > 3).getOrElse(false)
+    def isSatisfiedBy(user: GHUser) = Option(user.getName()).map(_.length > 1).getOrElse(false)
   })
 }
 


### PR DESCRIPTION
The current limit doesn't accept someone on our team whose name is 'bob'. The current `> 3` characters is also western-centric and wouldn't allow, e.g. Chinese names like Bo.
