### PR TITLE
override template url to save us from Heroku

### DIFF
--- a/heroku.md
+++ b/heroku.md
@@ -3,7 +3,7 @@ Setting up _gu:who_ on Heroku
 
 Follow the [Heroku Quick-Start guide](https://devcenter.heroku.com/articles/quickstart) to get your developement environment setup with Heroku.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/guardian/gu-who)
 
 Manual Instructions
 -------------------


### PR DESCRIPTION
There's a bug on Heroku right now were the UI fails if the button is clicked from withing a file (not when the README is rendered at the root of the GitHub repo). This overrides that URL to circumvent the problem.

We're also working on a fix on our end.
