### PR TITLE
Let users know in the initial message that they have limited time

### DIFF
--- a/app/views/ghIssues/issue.scala.html
+++ b/app/views/ghIssues/issue.scala.html
@@ -11,4 +11,6 @@ Otherwise, we just need you to help us with a few things to keep our code safe a
 * @requirement.fixSummary(organ)
 }
 
+You have a limited amount of time to fix these issues, otherwise you'll be automatically removed from this organisation.
+
 Thanks for helping us out - it makes our lives a lot easier, and help keeps our code secure!


### PR DESCRIPTION
This was suggested by @afeld in https://github.com/guardian/gu-who/issues/47 - it's worth noting that users also receive a final warning 1 week before they're removed from the GitHub organisation:

https://github.com/guardian/gu-who/blob/cdd765e7d/app/views/ghIssues/memberUserUpdate.scala.html#L4-L6

![image](https://cloud.githubusercontent.com/assets/52038/9966739/71f58ccc-5e36-11e5-95ee-085688118be4.png)


