### PR TITLE
APPLICATION_SECRET required to run play on heroku

### DIFF
--- a/heroku.md
+++ b/heroku.md
@@ -16,6 +16,12 @@ $ cd gu-who
 $ git push git@heroku.com:gu-who-nologo.git master
 ```
 
+Set a Heroku config var (required for Scala Play framework apps), APPLICATION_SECRET (more details [here](https://playframework.com/documentation/2.4.x/ApplicationSecret)):
+
+```
+$ heroku config:set APPLICATION_SECRET=somethingreallylongandobscure?ABC:jfk
+```
+
 After Heroku deploy completes, your instance of _gu:who_ should be available:
 
 https://gu-who-nologo.herokuapp.com/


### PR DESCRIPTION
I got this error when following heroku.md manual instructions, setting
APPLICATION_SECRET fixed it for me.

2015-10-27T20:23:45.362643+00:00 app[web.1]: [error] p.a.l.CryptoConfigParser - The application secret has not been set, and we are in prod mode. Your application is not secure.
2015-10-27T20:23:45.362791+00:00 app[web.1]: [error] p.a.l.CryptoConfigParser - To set the application secret, please read http://playframework.com/documentation/latest/ApplicationSecret
2015-10-27T20:23:45.379405+00:00 app[web.1]: [error] p.c.s.n.PlayDefaultUpstreamHandler - Cannot invoke the action
2015-10-27T20:23:45.379408+00:00 app[web.1]: com.google.inject.ProvisionException: Unable to provision, see the following errors:
2015-10-27T20:23:45.379410+00:00 app[web.1]:
2015-10-27T20:23:45.379411+00:00 app[web.1]: 1) Error in custom provider, @6o0l4eg03: Configuration error
2015-10-27T20:23:45.379412+00:00 app[web.1]:   while locating play.api.libs.CryptoConfigParser
2015-10-27T20:23:45.379412+00:00 app[web.1]:   while locating play.api.libs.CryptoConfig
2015-10-27T20:23:45.379413+00:00 app[web.1]:     for parameter 0 at play.api.libs.Crypto.<init>(Crypto.scala:282)
2015-10-27T20:23:45.379414+00:00 app[web.1]:   at play.api.inject.BuiltinModule.bindings(BuiltinModule.scala:48):
2015-10-27T20:23:45.379415+00:00 app[web.1]: Binding(class play.api.libs.Crypto to self) (via modules: com.google.inject.util.Modules$OverrideModule -> play.api.inject.guice.GuiceableModuleConversions$$anon$1)
2015-10-27T20:23:45.379416+00:00 app[web.1]:   while locating play.api.libs.Crypto