### PR TITLE
Take no action if ALL users have problems, as GitHub API may be broken

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -50,12 +50,16 @@ object Application extends Controller {
     new Dogpile[OrgSnapshot](
       for (orgSnapshot <- OrgSnapshot(auditDef)) yield {
         Logger.info(s"availableRequirementEvaluators=${orgSnapshot.availableRequirementEvaluators} ${orgSnapshot.orgUserProblemStats}")
-        orgSnapshot.createIssuesForNewProblemUsers()
 
-        orgSnapshot.updateExistingAssignedIssues()
+        if (orgSnapshot.soManyUsersHaveProblemsThatPerhapsTheGitHubAPIIsBroken) {
+          Logger.error(s"usersWithProblemsCount=${orgSnapshot.usersWithProblemsCount} - it's possible the GitHub API is broken, so no action will be taken, to avoid spamming users")
+        } else {
+          orgSnapshot.createIssuesForNewProblemUsers()
 
-        orgSnapshot.closeUnassignedIssues()
+          orgSnapshot.updateExistingAssignedIssues()
 
+          orgSnapshot.closeUnassignedIssues()
+        }
         orgSnapshot
       }
     )

--- a/app/lib/OrgSnapshot.scala
+++ b/app/lib/OrgSnapshot.scala
@@ -100,6 +100,10 @@ case class OrgSnapshot(
 
   lazy val usersWithProblemsCount = orgUserProblemsByUser.values.count(_.problems.nonEmpty)
 
+  lazy val proportionOfUsersWithProblems = usersWithProblemsCount.toFloat / users.size
+
+  lazy val soManyUsersHaveProblemsThatPerhapsTheGitHubAPIIsBroken = proportionOfUsersWithProblems > 0.9
+
   lazy val problemUsersExist = usersWithProblemsCount > 0
 
   lazy val orgUserProblemStats = orgUserProblemsByUser.values.map(_.problems.size).groupBy(identity).mapValues(_.size)

--- a/app/views/userPages/results.scala.html
+++ b/app/views/userPages/results.scala.html
@@ -5,12 +5,24 @@
 
     <div class="row">
         <div class="col-md-12">
-            <h2>Your audit is complete</h2>
-            <div class="alert alert-@if(orgSnapshot.problemUsersExist) {warning} else {success}">
-            <p>There are currently <a href="https://github.com/@auditDef.org.getLogin/people/issues/created_by/@auditDef.bot.getLogin?state=open"><strong>@orgSnapshot.usersWithProblemsCount</strong> users</a>
-                in @auditDef.org.displayName's organisation that don't meet requirements.
-            </p>
-            </div>
+            @if(orgSnapshot.soManyUsersHaveProblemsThatPerhapsTheGitHubAPIIsBroken) {
+                <div class="alert alert-danger">
+                    <h2>Possible problem with the GitHub API...</h2>
+                    <p>The audit found <strong>@orgSnapshot.usersWithProblemsCount</strong> users
+                        in @auditDef.org.displayName's organisation that don't meet requirements - this is such a large
+                        proprortion of your organisation that no action will be taken by gu:who - it's possible the GitHub
+                        API is currently broken.
+                    </p>
+                </div>
+            } else {
+                <h2>Your audit is complete</h2>
+                <div class="alert alert-@if(orgSnapshot.problemUsersExist) {warning} else {success}">
+                    <p>There are currently <a href="https://github.com/@auditDef.org.getLogin/people/issues/created_by/@auditDef.bot.getLogin?state=open"><strong>@orgSnapshot.usersWithProblemsCount</strong> users</a>
+                        in @auditDef.org.displayName's organisation that don't meet requirements.
+                    </p>
+                </div>
+            }
+
             <p>You can re-run this process, and update the associated issues, by calling our endpoint directly:</p>
 
             <code>curl -X POST -H "Csrf-Token: nocheck" -H "Authorization: token {{ YOUR_GITHUB_API_KEY }}" http://@req.host/audit/@auditDef.org.getLogin</code>


### PR DESCRIPTION
This change will instead log an error, and display an error to the user, if more than 90% of org users appear to have problems.

![image](https://cloud.githubusercontent.com/assets/52038/15571566/6f1b5d5c-2333-11e6-81bc-7149b130b499.png)

At 06:20:20 UTC we had an hour-long period where GitHub's `2fa_disabled` filter stopped working, resulting in [many users in our organisation getting spammed](https://github.com/guardian/people/issues?utf8=%E2%9C%93&q=is%3Aclosed+created%3A2016-05-26)


cc @rrees @mchv 



---------- Forwarded message ----------
From: support@github.com
Date: 26 May 2016 at 10:43
Subject: Re: API: '2fa_disabled' incorrectly true for all org users for 1h36m

Hi Roberto,

Thanks for reaching out about this and sorry for the trouble. This was indeed a problem on our end which should have been resolved in the meantime (and based on what you wrote, it seems like you've confirmed the problem is no longer happening). We have an issue open to investigate this further and prevent this from happening again.

Thanks again and let me know if you have any other questions.


> The GItHub API /orgs/:org/members '2fa_disabled' filter broke for the @guardian organisation last night, returning *all* 213 users in our organisation, rather than just the 4 that actually had 2FA disabled.
>
> https://developer.github.com/v3/orgs/members/#audit-two-factor-auth
>
> ...a lot of gu:who spam was sent as a result! :(
>
> Logs from gu-who (times in UTC):
>
> May 25 21:55:54 gu-who app/web.1: [info] application - 2fa_disabled count: Success(4)
> May 26 06:20:20 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:30 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:32 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:33 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:35 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:36 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:37 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:43 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:56 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:57 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:57 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:57 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 06:20:57 gu-who app/web.1: [info] application - 2fa_disabled count: Success(213)
> May 26 07:56:09 gu-who app/web.1: [info] application - 2fa_disabled count: Success(4)
>
> https://github.com/guardian/gu-who/blob/666997a/app/lib/OrgSnapshot.scala#L56