### PR TITLE
Fix regex for github personal access tokens.

### DIFF
--- a/app/views/userPages/index.scala.html
+++ b/app/views/userPages/index.scala.html
@@ -16,7 +16,7 @@
             @helper.form(action = routes.Application.storeApiKey, 'class -> "form") {
             @CSRF.formField
             <div class="input-group">
-                <input type="password" id="apiKey" name="apiKey" value="" size="40" maxlength="40" pattern="[0-9A-Fa-f]{40}" class="form-control input-lg" style="font-family: monospace;">
+                <input type="password" id="apiKey" name="apiKey" value="" size="40" maxlength="255" pattern="[A-Za-z0-9_]{40,255}" class="form-control input-lg" style="font-family: monospace;">
                 <span class="input-group-btn">
                     <button class="btn btn-primary input-lg" type="submit">Go!</button>
                 </span>


### PR DESCRIPTION
Updated regex as it was failing to validate valid github personal access tokens.

## What does this change?

Fixes the regex so valid personal access tokens from github can be used. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run the application locally as described [here](https://github.com/guardian/gu-who#local-deployment).
Create a personal access token as described [here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
Paste in the access token. 
Note the application works as expected. 

You can try against the main version to verify your access token is not accepted. 

## How can we measure success?

It's possible to run the application using personal access tokens. 

## Have we considered potential risks?

The regex is wrong and incorrectly accepts invalid access tokens. I have done some research and it seems the regex is correct but I cannot find any official github documentation to support this. 

## Images

n/a
