### PR TITLE
Update link to set 2FA in GitHub

### DIFF
--- a/app/lib/AccountRequirement.scala
+++ b/app/lib/AccountRequirement.scala
@@ -77,7 +77,7 @@ object TwoFactorAuthRequirement extends AccountRequirement {
 
   override def fixSummary(implicit org: GHOrganization) =
     "Enable [two-factor authentication](https://help.github.com/articles/about-two-factor-authentication) " +
-      "in your [GitHub account settings](https://github.com/settings/admin)."
+      "in your [GitHub Account Security settings](https://github.com/settings/security)."
 
   def userEvaluatorFor(orgSnapshot: OrgSnapshot) = for (tfaDisabledUsers <- orgSnapshot.twoFactorAuthDisabledUserLogins) yield
     new UserEvaluator {


### PR DESCRIPTION
Looks like the admin page in GitHub settings has moved to https://github.com/settings/security:

![image](https://user-images.githubusercontent.com/52038/113690143-02851f80-96c3-11eb-8729-4102f5a0dc26.png)

