### PR TITLE
Bump to Scala 2.11.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-- 2.11.7
+- 2.11.12
 jdk:
 - openjdk8
 sudo: false

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "gu-who"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.12"
 
 updateOptions := updateOptions.value.withCachedResolution(true)
 


### PR DESCRIPTION
We should really be on at least 2.13, but this is just a test commit to trigger travis.
