### PR TITLE
Add log line showing default branch name

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-
 import com.madgag.playgithub.auth.AuthenticatedSessions.AccessToken
 import lib.Implicits._
 import lib._
@@ -46,11 +45,16 @@ object Application extends Controller {
     }
   }
 
-  def scan(auditDef: AuditDef) = Cache.getOrElse(auditDef.toString) {
-    new Dogpile[OrgSnapshot](
-      for (orgSnapshot <- OrgSnapshot(auditDef)) yield {
-        Logger.info(s"availableRequirementEvaluators=${orgSnapshot.availableRequirementEvaluators} ${orgSnapshot.orgUserProblemStats}")
+  def scan(auditDef: AuditDef) =
+    Cache
+      .getOrElse(auditDef.toString) {
+        new Dogpile[OrgSnapshot](
+          for (orgSnapshot <- OrgSnapshot(auditDef)) yield {
+            Logger.info(
+              s"availableRequirementEvaluators=${orgSnapshot.availableRequirementEvaluators} ${orgSnapshot.orgUserProblemStats}"
+            )
 
+            /*
         if (orgSnapshot.soManyUsersHaveProblemsThatPerhapsTheGitHubAPIIsBroken) {
           Logger.error(s"usersWithProblemsCount=${orgSnapshot.usersWithProblemsCount} - it's possible the GitHub API is broken, so no action will be taken, to avoid spamming users")
         } else {
@@ -60,10 +64,13 @@ object Application extends Controller {
 
           orgSnapshot.closeUnassignedIssues()
         }
-        orgSnapshot
+             */
+
+            orgSnapshot
+          }
+        )
       }
-    )
-  }.doAtLeastOneMore()
+      .doAtLeastOneMore()
 
   def index = Action { implicit req =>
     Ok(views.html.userPages.index(apiKeyForm))
@@ -73,7 +80,9 @@ object Application extends Controller {
 
   def storeApiKey() = Action(parse.form(apiKeyForm)) { implicit req =>
     val accessToken = req.body
-    Redirect("/choose-your-org").withSession(AccessToken.SessionKey -> accessToken)
+    Redirect("/choose-your-org").withSession(
+      AccessToken.SessionKey -> accessToken
+    )
   }
 
   def chooseYourOrg = GitHubAuthenticatedAction { implicit req =>

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+
 import com.madgag.playgithub.auth.AuthenticatedSessions.AccessToken
 import lib.Implicits._
 import lib._
@@ -45,16 +46,11 @@ object Application extends Controller {
     }
   }
 
-  def scan(auditDef: AuditDef) =
-    Cache
-      .getOrElse(auditDef.toString) {
-        new Dogpile[OrgSnapshot](
-          for (orgSnapshot <- OrgSnapshot(auditDef)) yield {
-            Logger.info(
-              s"availableRequirementEvaluators=${orgSnapshot.availableRequirementEvaluators} ${orgSnapshot.orgUserProblemStats}"
-            )
+  def scan(auditDef: AuditDef) = Cache.getOrElse(auditDef.toString) {
+    new Dogpile[OrgSnapshot](
+      for (orgSnapshot <- OrgSnapshot(auditDef)) yield {
+        Logger.info(s"availableRequirementEvaluators=${orgSnapshot.availableRequirementEvaluators} ${orgSnapshot.orgUserProblemStats}")
 
-            /*
         if (orgSnapshot.soManyUsersHaveProblemsThatPerhapsTheGitHubAPIIsBroken) {
           Logger.error(s"usersWithProblemsCount=${orgSnapshot.usersWithProblemsCount} - it's possible the GitHub API is broken, so no action will be taken, to avoid spamming users")
         } else {
@@ -64,13 +60,10 @@ object Application extends Controller {
 
           orgSnapshot.closeUnassignedIssues()
         }
-             */
-
-            orgSnapshot
-          }
-        )
+        orgSnapshot
       }
-      .doAtLeastOneMore()
+    )
+  }.doAtLeastOneMore()
 
   def index = Action { implicit req =>
     Ok(views.html.userPages.index(apiKeyForm))
@@ -80,9 +73,7 @@ object Application extends Controller {
 
   def storeApiKey() = Action(parse.form(apiKeyForm)) { implicit req =>
     val accessToken = req.body
-    Redirect("/choose-your-org").withSession(
-      AccessToken.SessionKey -> accessToken
-    )
+    Redirect("/choose-your-org").withSession(AccessToken.SessionKey -> accessToken)
   }
 
   def chooseYourOrg = GitHubAuthenticatedAction { implicit req =>

--- a/app/lib/PeopleRepo.scala
+++ b/app/lib/PeopleRepo.scala
@@ -42,6 +42,8 @@ object PeopleRepo {
     def getUpToDateRepo(): Repository = {
       val gitdir = dataDirectory / "people.git"
 
+      Logger.info(s"Using repo with default branch name: $defaultBranch")
+
       if (gitdir.exists) {
         Logger.info("Updating Git repo with fetch...")
         val repo = FileRepositoryBuilder.create(gitdir)

--- a/app/views/userPages/orgs.scala.html
+++ b/app/views/userPages/orgs.scala.html
@@ -7,7 +7,7 @@
     <div class="row">
         <div class="col-md-3"></div>
         <div class="col-md-6">
-            <h3>Audit your organisation</h3>
+            <h3>Choose which organisation to audit</h3>
             <p class="alert-warning">You're running <i>gu:who</i> as <a href="http://github.com/@user.getLogin">@user.atLogin</a>.
              All GitHub issues raised by <i>gu:who</i> will appear to be raised by this account.
             </p>


### PR DESCRIPTION
## What does this change?

Adds a log line showing which default branch name is used. This is required due to the previous change https://github.com/guardian/gu-who/pull/77 which supported branch names other than master. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run the application locally. Execute it against an organisation then view the log line in the console. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Easier debugging of any issues related to the change to default branch names rather than hardcoding of master.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

None in particular.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [n/a] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [n/a] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [n/a] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [n/a] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
