### PR TITLE
Upgrade org.kohsuke.github-api - fixes #101

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,8 @@ libraryDependencies ++= Seq(
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3-1",
   "com.madgag.scala-git" %% "scala-git-test" % "3.5" % "test",
   "org.scalatestplus" %% "play" % "1.4.0" % "test"
-)     
+)
+libraryDependencies += "org.kohsuke" % "github-api" % "1.323"
 
 sources in (Compile,doc) := Seq.empty
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR pins the new version of `org.kohsuke.github-api` library.

## How to test

I went ahead and created my own heroku app and deployed this new version there. It works. Well... the issue I suffered from is fixed. There are others, but that's another story.

## Have we considered potential risks?

Nope, I'm not a Scala developer, so I have no clue if this new version is a breaking change or anything.
So far so good tho.

Fix #101 